### PR TITLE
region integration suggestion.

### DIFF
--- a/game_apis/rest/api.py
+++ b/game_apis/rest/api.py
@@ -4,10 +4,11 @@ import yaml
 class API:
     ID = 'NONE'
 
-    def __init__(self, config, sandbox=False, local_config=False):
+    def __init__(self, config, sandbox=False, local_config=False, region=None):
         path = os.path.dirname(os.path.abspath(__file__))
         self.key_id, self.key_secret, self.key_passphrase = None, None, None
         self.sandbox = sandbox
+        self.region = region
         if not config:
             config = "config.yaml"
 

--- a/game_apis/rest/rest.py
+++ b/game_apis/rest/rest.py
@@ -5,12 +5,12 @@ from game_apis.rest.riot import Riot
 from game_apis.rest.pubg import Pubg
 
 class Rest:
-    def __init__(self, config=None, sandbox=False, local_config=False):
+    def __init__(self, config=None, sandbox=False, local_config=False, region=None):
         self.config = config
         self.lookup = {
-            'opendota': OpenDota(config,sandbox,local_config),
-            'riot': Riot(config,sandbox,local_config),
-            'pubg': Pubg(config,sandbox,local_config)
+            'opendota': OpenDota(config,sandbox,local_config, region),
+            'riot': Riot(config,sandbox,local_config, region),
+            'pubg': Pubg(config,sandbox,local_config, region)
         }
 
     def __getattr__(self, attr):

--- a/game_apis/rest/riot.py
+++ b/game_apis/rest/riot.py
@@ -14,7 +14,13 @@ class Riot(API):
     def _get(self, command: str, options = None):
         if options is None:
             options = {}
-        base_url = "{}{}".format(self.rest_api, command)
+
+        if self.region is not None:
+            rest_api = "https://{}.api.riotgames.com".format(self.region)
+        else:
+            rest_api = self.rest_api
+
+        base_url = "{}{}".format(rest_api, command)
 
         if self.key_id is not None:
             base_url = "{}?api_key={}".format(base_url, self.key_id)

--- a/test/rest/test_riot.py
+++ b/test/rest/test_riot.py
@@ -9,6 +9,11 @@ class TestRiot(unittest.TestCase):
         hello = riot.hello_world()
         assert hello['id'] == 585897
 
+    def test_region(self):
+        riot = Rest('config.yaml',region='oc1').Riot
+        hello = riot.hello_world()
+        assert hello['id'] == 651520
+
     def test_champion_masteries(self):
         riot = Rest('config.yaml').Riot
         summoner = riot.get_summoner_by_name('pandaxcentric')


### PR DESCRIPTION
Creating the option to explicitly ask for a region argument in the Rest constructor.

Alternatively, we can revoke this change and use **kwargs instead.